### PR TITLE
Add DefaultFromAddress option

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter()]
-    [string]$VersionPrefix = "1.1.0",
+    [string]$VersionPrefix = "1.2.0",
 
     [Parameter()]
     [int]$BuildNumber = 0,

--- a/src/TakNotify.Provider.SendGrid/SendGridOptions.cs
+++ b/src/TakNotify.Provider.SendGrid/SendGridOptions.cs
@@ -8,6 +8,7 @@ namespace TakNotify
     public class SendGridOptions : NotificationProviderOptions
     {
         internal static string Parameter_ApiKey = $"{SendGridConstants.DefaultName}_{nameof(Apikey)}";
+        internal static string Parameter_DefaultFromAddress = $"{SendGridConstants.DefaultName}_{nameof(DefaultFromAddress)}";
 
         /// <summary>
         /// Instantiate the <see cref="SendGridOptions"/>
@@ -15,6 +16,7 @@ namespace TakNotify
         public SendGridOptions()
         {
             Parameters.Add(Parameter_ApiKey, "");
+            Parameters.Add(Parameter_DefaultFromAddress, "");
         }
 
         /// <summary>
@@ -24,6 +26,15 @@ namespace TakNotify
         {
             get => Parameters[Parameter_ApiKey].ToString();
             set => Parameters[Parameter_ApiKey] = value;
+        }
+
+        /// <summary>
+        /// The default "From Address" that will be used if the <see cref="SendGridMessage.FromAddress"/> is empty
+        /// </summary>
+        public string DefaultFromAddress
+        {
+            get => Parameters[Parameter_DefaultFromAddress].ToString();
+            set => Parameters[Parameter_DefaultFromAddress] = value;
         }
     }
 }

--- a/src/TakNotify.Provider.SendGrid/TakNotify.Provider.SendGrid.csproj
+++ b/src/TakNotify.Provider.SendGrid/TakNotify.Provider.SendGrid.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Summary>The SendGrid Provider for TakNotify library</Summary>
     <Description>The SendGrid Provider for TakNotify library</Description>
-    <Authors>Frandi Dwi</Authors>
+    <Authors>frandi-dwi</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/TakNotify/TakNotify.Provider.SendGrid</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -16,12 +16,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="SendGrid" Version="9.13.2" />
-    <PackageReference Include="TakNotify" Version="1.1.0" />
+    <PackageReference Include="TakNotify" Version="1.1.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Add `DefaultFromAddress` to the `SendGridOptions` so the value can be set during configuration. It will be used as the default value when the `SendGridMessage.FromAddress` is empty
- Upgrade to use `TakNotify v1.1.1`
- Increase the package to version `v1.2.0`